### PR TITLE
Add config option for the read buffer size of the NNTP connection

### DIFF
--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -140,7 +140,7 @@ static const char* OPTION_QUOTASTARTDAY			= "QuotaStartDay";
 static const char* OPTION_DAILYQUOTA			= "DailyQuota";
 static const char* OPTION_REORDERFILES			= "ReorderFiles";
 static const char* OPTION_UPDATECHECK			= "UpdateCheck";
-static const char* OPTION_CONNECTIONREADBUFFER		= "ConnectionReadBuffer";
+static const char* OPTION_ARTICLEREADCHUNKSIZE		= "ArticleReadChunkSize";
 
 // obsolete options
 static const char* OPTION_POSTLOGKIND			= "PostLogKind";
@@ -526,7 +526,7 @@ void Options::InitDefaults()
 	SetOption(OPTION_DAILYQUOTA, "0");
 	SetOption(OPTION_REORDERFILES, "no");
 	SetOption(OPTION_UPDATECHECK, "none");
-	SetOption(OPTION_CONNECTIONREADBUFFER, "4");
+	SetOption(OPTION_ARTICLEREADCHUNKSIZE, "4");
 }
 
 void Options::InitOptFile()
@@ -730,7 +730,7 @@ void Options::InitOptions()
 	m_monthlyQuota			= ParseIntValue(OPTION_MONTHLYQUOTA, 10);
 	m_quotaStartDay			= ParseIntValue(OPTION_QUOTASTARTDAY, 10);
 	m_dailyQuota			= ParseIntValue(OPTION_DAILYQUOTA, 10);
-	m_connectionReadBuffer		= ParseIntValue(OPTION_CONNECTIONREADBUFFER, 10) * 1024;
+	m_articleReadChunkSize		= ParseIntValue(OPTION_ARTICLEREADCHUNKSIZE, 10) * 1024;
 
 	m_nzbLog				= (bool)ParseEnumValue(OPTION_NZBLOG, BoolCount, BoolNames, BoolValues);
 	m_appendCategoryDir		= (bool)ParseEnumValue(OPTION_APPENDCATEGORYDIR, BoolCount, BoolNames, BoolValues);

--- a/daemon/main/Options.cpp
+++ b/daemon/main/Options.cpp
@@ -140,6 +140,7 @@ static const char* OPTION_QUOTASTARTDAY			= "QuotaStartDay";
 static const char* OPTION_DAILYQUOTA			= "DailyQuota";
 static const char* OPTION_REORDERFILES			= "ReorderFiles";
 static const char* OPTION_UPDATECHECK			= "UpdateCheck";
+static const char* OPTION_CONNECTIONREADBUFFER		= "ConnectionReadBuffer";
 
 // obsolete options
 static const char* OPTION_POSTLOGKIND			= "PostLogKind";
@@ -525,6 +526,7 @@ void Options::InitDefaults()
 	SetOption(OPTION_DAILYQUOTA, "0");
 	SetOption(OPTION_REORDERFILES, "no");
 	SetOption(OPTION_UPDATECHECK, "none");
+	SetOption(OPTION_CONNECTIONREADBUFFER, "4");
 }
 
 void Options::InitOptFile()
@@ -728,6 +730,7 @@ void Options::InitOptions()
 	m_monthlyQuota			= ParseIntValue(OPTION_MONTHLYQUOTA, 10);
 	m_quotaStartDay			= ParseIntValue(OPTION_QUOTASTARTDAY, 10);
 	m_dailyQuota			= ParseIntValue(OPTION_DAILYQUOTA, 10);
+	m_connectionReadBuffer		= ParseIntValue(OPTION_CONNECTIONREADBUFFER, 10) * 1024;
 
 	m_nzbLog				= (bool)ParseEnumValue(OPTION_NZBLOG, BoolCount, BoolNames, BoolValues);
 	m_appendCategoryDir		= (bool)ParseEnumValue(OPTION_APPENDCATEGORYDIR, BoolCount, BoolNames, BoolValues);

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -305,6 +305,8 @@ public:
 	Categories* GetCategories() { return &m_categories; }
 	Category* FindCategory(const char* name, bool searchAliases) { return m_categories.FindCategory(name, searchAliases); }
 
+	int GetConnectionReadBuffer() { return m_connectionReadBuffer; }
+
 	// Current state
 	void SetServerMode(bool serverMode) { m_serverMode = serverMode; }
 	bool GetServerMode() { return m_serverMode; }
@@ -434,6 +436,7 @@ private:
 	bool m_reorderFiles = false;
 	EFileNaming m_fileNaming = nfArticle;
 	int m_downloadRate = 0;
+	int m_connectionReadBuffer = 0;
 
 	// Application mode
 	bool m_serverMode = false;

--- a/daemon/main/Options.h
+++ b/daemon/main/Options.h
@@ -305,7 +305,7 @@ public:
 	Categories* GetCategories() { return &m_categories; }
 	Category* FindCategory(const char* name, bool searchAliases) { return m_categories.FindCategory(name, searchAliases); }
 
-	int GetConnectionReadBuffer() { return m_connectionReadBuffer; }
+	int GetArticleReadChunkSize() { return m_articleReadChunkSize; }
 
 	// Current state
 	void SetServerMode(bool serverMode) { m_serverMode = serverMode; }
@@ -436,7 +436,7 @@ private:
 	bool m_reorderFiles = false;
 	EFileNaming m_fileNaming = nfArticle;
 	int m_downloadRate = 0;
-	int m_connectionReadBuffer = 0;
+	int m_articleReadChunkSize = 0;
 
 	// Application mode
 	bool m_serverMode = false;

--- a/daemon/nntp/ArticleDownloader.cpp
+++ b/daemon/nntp/ArticleDownloader.cpp
@@ -335,7 +335,7 @@ ArticleDownloader::EStatus ArticleDownloader::Download()
 	m_decoder.SetRawMode(g_Options->GetRawArticle());
 
 	status = adRunning;
-	CharBuffer lineBuf(1024*4);
+	CharBuffer lineBuf(g_Options->GetConnectionReadBuffer());
 
 	while (!IsStopped() && !m_decoder.GetEof())
 	{

--- a/daemon/nntp/ArticleDownloader.cpp
+++ b/daemon/nntp/ArticleDownloader.cpp
@@ -335,7 +335,7 @@ ArticleDownloader::EStatus ArticleDownloader::Download()
 	m_decoder.SetRawMode(g_Options->GetRawArticle());
 
 	status = adRunning;
-	CharBuffer lineBuf(g_Options->GetConnectionReadBuffer());
+	CharBuffer lineBuf(g_Options->GetArticleReadChunkSize());
 
 	while (!IsStopped() && !m_decoder.GetEof())
 	{

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -1071,8 +1071,8 @@ QuotaStartDay=1
 DailyQuota=0
 
 
-# Readbuffer size for the connections to the news server (kilobytes).
-ConnectionReadBuffer=4
+# Chunk size when reading data from the news server (kilobytes).
+ArticleReadChunkSize=4
 
 
 ##############################################################################

--- a/nzbget.conf
+++ b/nzbget.conf
@@ -1071,6 +1071,10 @@ QuotaStartDay=1
 DailyQuota=0
 
 
+# Readbuffer size for the connections to the news server (kilobytes).
+ConnectionReadBuffer=4
+
+
 ##############################################################################
 ### LOGGING                                                                ###
 


### PR DESCRIPTION
Created a config switch (see discussion in https://github.com/nzbget-ng/nzbget/pull/12) for configuring the read buffer size of the NNTP connection in the web UI.
Works on my local system but might need further testing.
Updating the nzbget binary manually will require to change the `webui/nzbget.conf.template` file of the nzbget installation manually (add the new config switch) as long as there is no build which can create a proper installer with the new template.
The following must be added manually to the file `webui/nzbget.conf.template`:
```

# Readbuffer size for the connections to the news server (kilobytes).
ConnectionReadBuffer=4
```
Afterwards the should be a new config switch in the web ui (under Settings->CONNECTION). Default value is 4 KiB (same as before).