### PR TITLE
Fix stuck script execution

### DIFF
--- a/daemon/util/Script.cpp
+++ b/daemon/util/Script.cpp
@@ -634,13 +634,13 @@ void ScriptController::StartProcess(int* pipein, int* pipeout)
 
 #ifdef CHILD_WATCHDOG
 		fputc( '\n', stdout );
-		fsync(1);
+		fflush( stdout );
 #endif
 
 		if ( chdir( workingDir ) == -1 )
         {
             fprintf( stdout, "[ERROR] Could not change working directory for %s: %s\n", script, strerror(errno) );
-            fsync(1);
+            fflush( stdout );
             _exit(FORK_ERROR_EXIT_CODE);
         }
 		environ = envdata;
@@ -650,7 +650,7 @@ void ScriptController::StartProcess(int* pipein, int* pipeout)
 		if ( errno == EACCES )
 		{
 			fprintf( stdout, "[WARNING] Fixing permissions for %s\n", script );
-            fsync(1);
+            fflush( stdout );
 			FileSystem::FixExecPermission(script);
 			execvp(script, argdata);
 		}
@@ -658,7 +658,7 @@ void ScriptController::StartProcess(int* pipein, int* pipeout)
 		// NOTE: the text "[ERROR] Could not start " is checked later,
 		// if changed, adjust the dependent code below.
         fprintf( stdout, "[ERROR] Could not start %s: %s\n", script, strerror(errno) );
-		fsync(1);
+		fflush( stdout );
 		_exit(FORK_ERROR_EXIT_CODE);
 	}
 


### PR DESCRIPTION
This fixes script execution on Linux.

As bisected by @bacon-cheeseburger in nzbget-ng/nzbget-issues#22, 8ca0364a5891f6d032c50d57369b9dee9620f863 subtly broke the `CHILD_WATCHDOG` feature when executing scripts. Switching from `write` to `fputc` means that the newline character was no longer written directly to the `stdout` fd, but an internal `stdio` buffer. This buffer is not flushed by `fsync`, which means the watchdog won't receive the newline and the buffer is lost on `execvp` afterwards.

When the script does not produce at least on line of output, the child watchdog assumes the script execution has failed and retries the execution.

Fixes nzbget-ng/nzbget-issues#22