### PR TITLE
Workaround for systems that do not have libcap

### DIFF
--- a/daemon/main/nzbget.h
+++ b/daemon/main/nzbget.h
@@ -208,7 +208,9 @@ using namespace MSXML;
 #include <time.h>
 #include <ctype.h>
 #include <inttypes.h>
+#ifdef HAVE_SYS_CAPABILITY_H
 #include <sys/capability.h>
+#endif
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
492bf67f seems to suggest that functionalities offered by libcap are part of POSIX, which is not true. From
https://man7.org/linux/man-pages/man3/libcap.3.html#DESCRIPTION:

  These primary functions work on a capability state held in working
  storage and attempt to complete the POSIX.1e (draft) user space API
  for Capability based privilege.

This fixes building on OpenBSD.