### PR TITLE
Use ftruncate(2) instead of posix_fallocate(2) on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_FUNC_MKTIME
 AC_FUNC_REALLOC
 AC_FUNC_STRERROR_R
 AC_FUNC_STRNLEN
-AC_CHECK_FUNCS([bzero dup2 fdatasync floor getcwd gethostbyname gettimeofday inet_ntoa memchr memmove memset mkdir pow realpath regcomp rmdir select socket strcasecmp strchr strdup strerror strncasecmp strpbrk strrchr strspn strstr strtol strtoul])
+AC_CHECK_FUNCS([bzero dup2 fdatasync floor getcwd gethostbyname gettimeofday inet_ntoa memchr memmove memset mkdir posix_fallocate pow realpath regcomp rmdir select socket strcasecmp strchr strdup strerror strncasecmp strpbrk strrchr strspn strstr strtol strtoul])
 
 #
 # Android NDK restrictions

--- a/daemon/util/FileSystem.cpp
+++ b/daemon/util/FileSystem.cpp
@@ -291,7 +291,11 @@ bool FileSystem::AllocateFile(const char* filename, int64 size, bool sparse, CSt
 		return false;
 	}
 
+#ifdef HAVE_POSIX_FALLOCATE
     if ( posix_fallocate( fileno( file ), 0, size ) != 0 ) {
+#else
+    if (ftruncate(fileno(file), size) != 0) {
+#endif
         errmsg = GetLastErrorMessage();
         fclose(file);
         return false;


### PR DESCRIPTION
The latter, which has been introduced by c8f2fc4e, is not available on OpenBSD, and most likely some other systems.